### PR TITLE
fix: fix the problem of Chinese character garbling

### DIFF
--- a/apple_notes_to_sqlite/cli.py
+++ b/apple_notes_to_sqlite/cli.py
@@ -168,7 +168,7 @@ def extract_notes():
     note = {}
     body = []
     for line in process.stdout:
-        line = line.decode("mac_roman").strip()
+        line = line.decode("utf8").strip()
         if line == f"{split}{split}":
             if note.get("id"):
                 note["body"] = "\n".join(body).strip()
@@ -197,7 +197,7 @@ def extract_folders():
     for line in process.stdout:
         for key in ("long_id", "name", "parent"):
             if line.startswith(f"{key}: ".encode("utf8")):
-                folder[key] = line[len(f"{key}: ") :].decode("macroman").strip() or None
+                folder[key] = line[len(f"{key}: ") :].decode("utf8").strip() or None
                 continue
         if line == b"===\n":
             folders.append(folder)


### PR DESCRIPTION
1. The code uses two different ways of writing encoding formats, `mac_roman` and `macroman`. It is uncertain whether there are any typo errors.
2. When there are Chinese characters in the content, exporting it results in garbled code. Changing it to `utf8` can fix the issue.